### PR TITLE
Revision

### DIFF
--- a/src/nomad_plugin_qutip/schema_packages/schema.py
+++ b/src/nomad_plugin_qutip/schema_packages/schema.py
@@ -8,9 +8,8 @@ from .schema_package import (
     QuantumOperator,
     QuantumSimulation,
     QuantumSystem,
-    QuantumCircuit, #Needed?
     QuantumState,
-    ModelHamiltonian,      
+    ModelHamiltonian,
     HamiltonianParameter
 )
 
@@ -104,7 +103,7 @@ QuantumSimulation.quantum_states.m_def.m_annotations.setdefault(
 ).update(
     dict(
         info=Mapper(
-            mapper=('get_states', ['.quantum_states']),  
+            mapper=('get_states', ['.quantum_states']),
             sub_section=QuantumState.m_def,
             repeats=True,
         )
@@ -120,20 +119,6 @@ QuantumState.quantum_object.m_annotations.setdefault(
 ).update(dict(info=Mapper(mapper='.quantum_object', sub_section=QuantumObject.m_def)))
 
 
-###### Quantum circuit
-'''
-QuantumSimulation.quantum_circuit.m_annotations.setdefault(
-    MAPPING_ANNOTATION_KEY, {}
-).update(
-    dict(
-        info=Mapper(
-            mapper=('get_circuit', ['.@']),  
-            sub_section=QuantumCircuit.m_def,
-            repeats=False, 
-        )
-    )
-)
-'''
 # --- Mapping for QuantumObject internal fields ---
 QuantumObject.dims.m_annotations.setdefault(MAPPING_ANNOTATION_KEY, {}).update(
     dict(info=Mapper(mapper='.dims'))

--- a/src/nomad_plugin_qutip/schema_packages/schema_package.py
+++ b/src/nomad_plugin_qutip/schema_packages/schema_package.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 import numpy as np
 from nomad.config import config
-from nomad.datamodel.data import Schema,ArchiveSection 
+from nomad.datamodel.data import Schema,ArchiveSection
 from nomad.datamodel.metainfo.annotations import ELNAnnotation, ELNComponentEnum, SectionProperties
 from nomad.metainfo import MEnum, Quantity, SchemaPackage, SubSection, Section
 from nomad_simulations.schema_packages.general import Simulation
@@ -154,15 +154,6 @@ class QuantumState(ArchiveSection):
     )
 
 
-class QuantumCircuit(ArchiveSection):
-    """
-    A container for gate-based quantum circuits, e.g., from OpenQASM or Cirq.
-    """
-
-    circuit_representation = Quantity(
-        type=str, description='Circuit definition (OpenQASM, Cirq JSON, etc.).'
-    )
-
 class HamiltonianParameter(ArchiveSection):
     """Stores a single named parameter used in the Hamiltonian formula."""
     m_def = Section(
@@ -188,7 +179,7 @@ class HamiltonianParameter(ArchiveSection):
     )
 
 
-class ModelHamiltonian(ArchiveSection): 
+class ModelHamiltonian(ArchiveSection):
     """
     Describes the model Hamiltonian using a formula and parameters.
     """
@@ -241,19 +232,13 @@ class QuantumSimulation(Simulation):
         description='List of quantum states (initial states, final states, etc.).',
     )
 
-    quantum_circuit = SubSection(
-        sub_section=QuantumCircuit.m_def,
-        repeats=False,
-        description='Gate-based circuit if relevant to this calculation.',
-    )
-
     hamiltonian_description = SubSection(
         section_def=ModelHamiltonian,
         description="""
         Describes the model Hamiltonian using a formula and parameters.
         """
     )
-    #It lacks the possibility of plotting the eigenvalues in function of a variable. So it should plot 
+    #It lacks the possibility of plotting the eigenvalues in function of a variable. So it should plot
     #something from a list of lists (as the eigenvalues) on a variable.
     #It should also have the possibility of plotting time evolutions, more or less
     # what is seen here https://qutip.org/docs/4.0.2/modules/qutip/mesolve.html , the final state is handled by states


### PR DESCRIPTION
here we can discuss strategies to better integrate the Hamiltonian and operator parts of the custom schema with the nomad‐simulations base sections. The idea is not to reinvent the wheel but rather to leverage the already defined abstractions (like `BaseModelMethod` and `ModelMethod`) so that your schema is consistent with and reuses the normalization and contribution‐handling logic already present in nomad‐simulations.

nomad‑simulations defines a hierarchy of classes that are meant  to describe the Hamiltonian and its individual contributions (or  “terms”) in a modular way. For instance, the base class `BaseModelMethod` provides common fields (like name, type, external_reference) and normalization steps, while `ModelMethod` further decomposes a Hamiltonian into a list of contributions. 

in this PR i will list these minor improvements